### PR TITLE
Remove check for default title

### DIFF
--- a/cypress/integration/search-and-compare-ui/basic.spec.ts
+++ b/cypress/integration/search-and-compare-ui/basic.spec.ts
@@ -5,14 +5,6 @@ describe("Basic", () => {
     cy.visit(URL);
   });
 
-  afterEach(() => {
-    cy.checkForDefaultTitle();
-  });
-
-  it("should have correct title", () => {
-    cy.title().should("include", "Find courses by location or by training provider");
-  });
-
   it("should show a validation error if user does not select a location", () => {
     cy.contains("Continue").click();
     cy.get(".govuk-error-summary").should("exist");

--- a/cypress/integration/search-and-compare-ui/geocoding.spec.ts
+++ b/cypress/integration/search-and-compare-ui/geocoding.spec.ts
@@ -5,10 +5,6 @@ describe("Geocoding", () => {
     cy.visit(URL);
   });
 
-  afterEach(() => {
-    cy.checkForDefaultTitle();
-  });
-
   it("should let user search by location", () => {
     cy.contains("By postcode").click();
     cy.get("#location").type("westmin");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -23,9 +23,3 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-
-const DEFAULT_PAGE_TITLE = "Find postgraduate teacher training in England - GOV.UK";
-
-Cypress.Commands.add("checkForDefaultTitle", () => {
-  cy.title().should("not.equal", DEFAULT_PAGE_TITLE);
-});


### PR DESCRIPTION
The main page in the location wizard now uses the default title, so we can't easily check all pages using this afterEach.